### PR TITLE
fix workflow checkout version 3 to 4

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -6,16 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    # uses v3 Stable version
+    # uses v4 Stable version
     # https://github.com/actions/checkout
     - name: checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     # Build Artifacts
     - name: Build distribution file
       uses: TechBooster/ReVIEW-build-artifact-action@master
     # Upload Distribution file
     - name: Upload distribution file to github artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Output documents
         path: ./articles/*.pdf


### PR DESCRIPTION
github actionsのバージョン変更テスト
未テスト

エラーメッセージ
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

資料
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

